### PR TITLE
Support nested attributes

### DIFF
--- a/templates/mixins.jade
+++ b/templates/mixins.jade
@@ -98,10 +98,10 @@ mixin Parameters(params)
                             code= self.urldec(value.value)
                             = ' '
 
-mixin Constraints(name, schema)
+mixin Constraints(name, description)
     each constraint in ['minLength', 'maxLength', 'pattern']
-        if schema.properties[name][constraint]
-            div #{constraint}: #{schema.properties[name][constraint]}
+        if description[constraint]
+            div #{constraint}: #{description[constraint]}
 
 
 mixin RequestResponse(title, request, collapse, showSchema)
@@ -147,13 +147,7 @@ mixin RequestResponseBody(request, collapse, showBlank, showSchema)
                             th Description
                             th Constraints
                             each description, name in schema.properties || []
-                                tr
-                                    td #{name}
-                                    td #{description.type}
-                                    td #{schema.required && schema.required.indexOf(name) >= 0 ? 'true' : ''}
-                                    td #{description.description}
-                                    td
-                                        +Constraints(name, schema)
+                                +AttributesTable(schema, name, description, '')
                 div.title
                     .collapse-button
                         span.close Hide
@@ -166,6 +160,18 @@ mixin RequestResponseBody(request, collapse, showBlank, showSchema)
             if !request.hasContent
                 .description.text-muted This response has no content.
                 div(style="height: 1px;")
+
+mixin AttributesTable(schema, name, description, indentation)
+    tr
+        td !{indentation}#{name}
+        td #{description.type}
+        td #{schema.required && schema.required.indexOf(name) >= 0 ? 'true' : ''}
+        td #{description.description}
+        td
+            +Constraints(name, description)
+    each childDescription, childName in description.properties || []
+        +AttributesTable(schema, childName, childDescription, indentation + '&nbsp;&nbsp;&nbsp;')
+
 
 mixin Examples(resourceGroup, resource, action)
     each example in action.examples


### PR DESCRIPTION
Hey there,

I'm writing a REST documentation and wanted to use API Blueprint syntax and aglio for rendering it. While searching for a possibility to show the attributes in a table, I found your fork via https://github.com/danielgtaylor/aglio/issues/103. 
Thanks for providing this feature, it helped me a lot! Still, it did not fully satisfy my needs, because in my API, the Attributes objects are nested. An example looks like this:

```
### modifyUser [POST]

modifies a user by their id

+ Request (application/json)
    + Attributes
        + userId: 1 (number, required)
        + userRecord (object, required) - fill in only the fields that are updated
            + username: username (string, optional)
            + password: password (string, optional) - unencrypted
            + email: email (string, optional)
            + base_role: contentViewer (string, optional) - role has to exist
```

I edited your template to be able to display arbitrary nested attributes. Each level is intented by three additional non-breaking spaces to display the depth.

Feel free to merge this feature into your repo!

Best regards,
Thorsten Hack
